### PR TITLE
Update Dockerfile to avoid permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,7 @@ RUN bundle update --bundler && \
 COPY ./supervisord.conf /etc/supervisord.conf 
 # copy the rest of files
 COPY . /app
-# Add user
-RUN addgroup --system --gid 1000 app && \
-    adduser --system --uid 1000 --home /app --group app && \
-    chmod 777 -R /app/tmp && \
-    chown -R app:app /app
 
-USER app
 RUN npm ci
 
 ENV RAILS_LOG_TO_STDOUT=1


### PR DESCRIPTION
Update Dockerfile to avoid permission issues when running decidim-hacks container